### PR TITLE
Fixes #13 - Worldgen Snow on Grass Blocks

### DIFF
--- a/src/main/java/dev/schmarrn/schnowy/mixin/SnowAndFreezeFeatureMixin.java
+++ b/src/main/java/dev/schmarrn/schnowy/mixin/SnowAndFreezeFeatureMixin.java
@@ -49,6 +49,10 @@ public class SnowAndFreezeFeatureMixin {
 					level.setBlock(below, belowStateWithSnow, 2);
 				} else {
 					level.setBlock(blockPos, Blocks.SNOW.defaultBlockState(), 2);
+					BlockState belowState = level.getBlockState(blockPos.below());
+					if (belowState.hasProperty(SnowyDirtBlock.SNOWY)) {
+						level.setBlock(blockPos.below(), belowState.setValue(SnowyDirtBlock.SNOWY, true), 2);
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Setting the correct BlockStates now when generating normal snow layers.
![image](https://user-images.githubusercontent.com/26302678/208095263-72476da8-5168-4f44-9069-b6d0548bbad0.png)
